### PR TITLE
feat: rewrite using `ureq` and add support for `tcp`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0.183", features = ["derive"] }
-serde_json = "1.0.104"
+serde = { version = "1.0.199", features = ["derive"] }
+serde_json = "1.0.116"
 ureq = "2.9.7"
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merrymake-service-library"
-version = "1.2.0"
+version = "2.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "merrymake-service-library"
-version = "1.0.1"
+version = "1.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.11.18", features = ["blocking"] }
 serde = { version = "1.0.183", features = ["derive"] }
 serde_json = "1.0.104"
+ureq = "2.9.7"
 
 [[example]]
 name = "minimal"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ path = "src/main.rs"
 Here is the most basic example of how to use this library:
 
 ```rust
-use merrymake_service_library::{merrymake_service, mime_types, reply_str_to_origin, Envelope};
+use merrymake_service_library::{merrymake_service, reply_str_to_origin, Envelope};
 use std::str;
 
 pub fn main() -> Result<(), String> {
@@ -38,7 +38,7 @@ pub fn main() -> Result<(), String> {
 
 pub fn handle_hello(buffer: Vec<u8>, _envelope: Envelope) -> Result<(), String> {
     let payload = str::from_utf8(&buffer).unwrap();
-    reply_str_to_origin(format!("Hello, {}!", payload), &mime_types::TXT).unwrap();
+    reply_str_to_origin(format!("Hello, {}!", payload))?;
     Ok(())
 }
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pub fn main() -> Result<(), String> {
 
 pub fn handle_hello(buffer: Vec<u8>, _envelope: Envelope) -> Result<(), String> {
     let payload = str::from_utf8(&buffer).unwrap();
-    reply_str_to_origin(format!("Hello, {}!", payload), mime_types::TXT).unwrap();
+    reply_str_to_origin(format!("Hello, {}!", payload), &mime_types::TXT).unwrap();
     Ok(())
 }
 ```

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,4 @@
-use merrymake_service_library::{merrymake_service, mime_types, reply_str_to_origin, Envelope};
+use merrymake_service_library::{merrymake_service, reply_str_to_origin, Envelope};
 use std::str;
 
 pub fn main() -> Result<(), String> {
@@ -13,6 +13,6 @@ pub fn main() -> Result<(), String> {
 
 pub fn handle_hello(buffer: Vec<u8>, _envelope: Envelope) -> Result<(), String> {
     let payload = str::from_utf8(&buffer).unwrap();
-    reply_str_to_origin(format!("Hello, {}!", payload), &mime_types::TXT).unwrap();
+    reply_str_to_origin(format!("Hello, {}!", payload))?;
     Ok(())
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -13,6 +13,6 @@ pub fn main() -> Result<(), String> {
 
 pub fn handle_hello(buffer: Vec<u8>, _envelope: Envelope) -> Result<(), String> {
     let payload = str::from_utf8(&buffer).unwrap();
-    reply_str_to_origin(format!("Hello, {}!", payload), mime_types::TXT).unwrap();
+    reply_str_to_origin(format!("Hello, {}!", payload), &mime_types::TXT).unwrap();
     Ok(())
 }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use serde::Deserialize;
 
 #[derive(Clone, Deserialize)]
@@ -19,11 +21,15 @@ pub struct Envelope {
 }
 
 impl Envelope {
-    pub fn from_str(json: &str) -> Result<Self, &'static str> {
-        serde_json::from_str(json).map_err(|_| "Unable to parse envelope from json")
-    }
-
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
         serde_json::from_slice(bytes).map_err(|_| "Unable to parse envelope from json")
+    }
+}
+
+impl FromStr for Envelope {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s).map_err(|_| "Unable to parse envelope from json")
     }
 }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -22,7 +22,7 @@ pub struct Envelope {
 
 impl Envelope {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
-        serde_json::from_slice(bytes).map_err(|_| "Unable to parse envelope from json")
+        serde_json::from_slice(bytes).map_err(|_| "Unable to parse envelope from bytes")
     }
 }
 

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -19,9 +19,11 @@ pub struct Envelope {
 }
 
 impl Envelope {
-    pub fn new(json: &str) -> Result<Self, &'static str> {
-        let envelope: Envelope =
-            serde_json::from_str(json).map_err(|_| "Unable to parse envelope from json")?;
-        Ok(envelope)
+    pub fn from_str(json: &str) -> Result<Self, &'static str> {
+        serde_json::from_str(json).map_err(|_| "Unable to parse envelope from json")
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
+        serde_json::from_slice(bytes).map_err(|_| "Unable to parse envelope from json")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,15 +19,19 @@ macro_rules! merrymake_service {
     ( { actions: { $( $action:literal : $handler:ident ) , * } $(, init: $init:ident )? } ) => {
         {
             use merrymake_service_library::merrymake::{get_args, get_payload};
-            let (arg_action, envelope) = get_args()?;
-            match arg_action.as_str() {
-                $(
-                    $action => $handler(get_payload()?, envelope),
-                )*
-                $(
-                    _ => $init(),
-                )?
-                _ => Ok(())
+            if (std::env::args().count() == 2) {
+                todo!()
+            } else {
+                let (arg_action, envelope) = get_args()?;
+                match arg_action.as_str() {
+                    $(
+                        $action => $handler(get_payload()?, envelope),
+                    )*
+                    $(
+                        _ => $init(),
+                    )?
+                    _ => Ok(())
+                }
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@ pub use mime_types::MimeType;
 macro_rules! merrymake_service {
     ( { actions: { $( $action:literal : $handler:ident ) , * } $(, init: $init:ident )? } ) => {
         {
-            use merrymake_service_library::merrymake::{get_args, get_payload};
-            if (std::env::args().count() == 2) {
+            use merrymake_service_library::merrymake::{tcp_is_enabled, get_args, get_payload};
+            if tcp_is_enabled() {
                 todo!()
             } else {
                 let (arg_action, envelope) = get_args()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,20 +18,16 @@ pub use mime_types::MimeType;
 macro_rules! merrymake_service {
     ( { actions: { $( $action:literal : $handler:ident ) , * } $(, init: $init:ident )? } ) => {
         {
-            use merrymake_service_library::merrymake::{tcp_is_enabled, get_args, get_payload};
-            if tcp_is_enabled() {
-                todo!()
-            } else {
-                let (arg_action, envelope) = get_args()?;
-                match arg_action.as_str() {
-                    $(
-                        $action => $handler(get_payload()?, envelope),
-                    )*
-                    $(
-                        _ => $init(),
-                    )?
-                    _ => Ok(())
-                }
+            use merrymake_service_library::merrymake::get_args;
+            let (arg_action, envelope, payload) = get_args()?;
+            match arg_action.as_str() {
+                $(
+                    $action => $handler(payload, envelope),
+                )*
+                $(
+                    _ => $init(),
+                )?
+                _ => Ok(())
             }
         }
     };

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -37,7 +37,7 @@ fn get_bytes() -> Result<Vec<u8>, String> {
     Ok(bytes)
 }
 
-fn length_to_bytes(length: usize) -> [u8; 3] {
+fn length_to_bytes(length: &usize) -> [u8; 3] {
     let bytes = length.to_be_bytes();
     [bytes[5], bytes[6], bytes[7]]
 }
@@ -102,9 +102,9 @@ fn pack(event: &str, body: &[u8], content_type: &MimeType) -> Result<Vec<u8>, St
 fn pack_rapids_payload(event: &str, body: &[u8]) -> Result<Vec<u8>, String> {
     let event = serde_json::to_vec(event).map_err(|e| e.to_string())?;
     let bytes = vec![
-        &length_to_bytes(event.len())[..],
+        &length_to_bytes(&event.len())[..],
         event.as_slice(),
-        &length_to_bytes(body.len())[..],
+        &length_to_bytes(&body.len())[..],
         body,
     ]
     .concat();

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -37,20 +37,22 @@ fn get_bytes() -> Result<Vec<u8>, String> {
     Ok(bytes)
 }
 
-fn bytes_to_number(bytes: &[u8]) -> Result<u32, &'static str> {
+fn bytes_to_number(bytes: &[u8]) -> Result<usize, &'static str> {
     if bytes.len() < 3 {
         Err("byte vector too small to interpret as number")
     } else {
-        let left = u32::from(bytes[0]) << 16;
-        let mid = u32::from(bytes[1]) << 8;
-        let right = u32::from(bytes[2]);
+        let left = usize::from(bytes[0]) << 16;
+        let mid = usize::from(bytes[1]) << 8;
+        let right = usize::from(bytes[2]);
         Ok(left | mid | right)
     }
 }
 
-fn read_next_byte_chunk(bytes: &[u8]) -> Result<(Vec<u8>, Vec<u8>), String> {
-    let len = bytes_to_number(&bytes[..2])?;
-    todo!()
+/// TODO: Maybe return `end` index instead so we avoid copying the bytes
+fn read_next_byte_chunk(bytes: &[u8]) -> Result<(Vec<u8>, Vec<u8>), &'static str> {
+    let len = bytes_to_number(&bytes[..3])?;
+    let end = len + 3;
+    Ok((Vec::from(&bytes[3..end]), Vec::from(&bytes[end..])))
 }
 
 /// Used for tcp

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -95,9 +95,16 @@ fn pack(event: &str, body: &[u8], content_type: &MimeType) -> Result<Vec<u8>, St
         // { content: Vec<u8>, headers: { contentType: String } }
         todo!()
     } else {
-        let event = serde_json::to_vec(event).map_err(|e| e.to_string())?;
-        let body = Vec::from(body);
-        let bytes = vec![event, body].concat();
+        let event = serde_json::to_vec(event)
+            .map_err(|e| e.to_string())?
+            .as_slice();
+        let bytes = vec![
+            &length_to_bytes(event.len())[..],
+            event,
+            &length_to_bytes(body.len())[..],
+            body,
+        ]
+        .concat();
         Ok(bytes)
     }
 }

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -1,5 +1,5 @@
 use crate::{mime_types, Envelope, MimeType};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::env;
 use std::fs::File;
 use std::io::{self, Read, Write};
@@ -38,7 +38,8 @@ fn get_bytes() -> Result<Vec<u8>, String> {
 }
 
 fn length_to_bytes(length: usize) -> [u8; 3] {
-    todo!()
+    let bytes = length.to_be_bytes();
+    [bytes[5], bytes[6], bytes[7]]
 }
 
 fn bytes_to_index(bytes: &[u8]) -> Result<usize, &'static str> {

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -30,12 +30,6 @@ pub fn post_to_rapids<T: serde::Serialize + ?Sized>(
     }
 }
 
-fn tcp_post_to_rapids(bytes: &[u8]) -> Result<(), String> {
-    let addr = env::var("RAPIDS").map_err(|_| "RAPIDS environment variable not set")?;
-    let mut stream = net::TcpStream::connect(addr).map_err(|e| e.to_string())?;
-    stream.write_all(bytes).map_err(|e| e.to_string())
-}
-
 /// Post an event to the central message queue (Rapids), with a payload and its
 /// content type.
 /// # Arguments
@@ -176,6 +170,12 @@ fn get_tcp_mode_args() -> Result<(String, Envelope, Vec<u8>), String> {
 /// Returns `true` if the `tcp` feature is enabled.
 fn tcp_is_enabled() -> bool {
     env::args().count() == 2
+}
+
+fn tcp_post_to_rapids(bytes: &[u8]) -> Result<(), String> {
+    let addr = env::var("RAPIDS").map_err(|_| "RAPIDS environment variable not set")?;
+    let mut stream = net::TcpStream::connect(addr).map_err(|e| e.to_string())?;
+    stream.write_all(bytes).map_err(|e| e.to_string())
 }
 
 fn http_post_to_rapids(

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -37,6 +37,10 @@ fn get_bytes() -> Result<Vec<u8>, String> {
     Ok(bytes)
 }
 
+fn length_to_bytes(length: usize) -> [u8; 3] {
+    todo!()
+}
+
 fn bytes_to_index(bytes: &[u8]) -> Result<usize, &'static str> {
     if bytes.len() < 3 {
         Err("byte vector too small to interpret as number")
@@ -66,6 +70,15 @@ pub fn get_args_and_action() -> Result<(String, Envelope, Vec<u8>), String> {
     Ok((action, envelope, payload))
 }
 
+/// Returns `true` if the `tcp` feature is enabled.
+pub fn tcp_is_enabled() -> bool {
+    env::args().count() == 2
+}
+
+fn pack(event: &str, body: &[u8], content_type: MimeType) -> Vec<u8> {
+    todo!()
+}
+
 fn internal_post_http_to_rapids(
     event: &str,
     request_completer: impl FnOnce(Request) -> Result<Response, ureq::Error>,
@@ -79,15 +92,6 @@ fn internal_post_http_to_rapids(
         .map_err(|_| format!("unable to post event '{}' to url '{}'", event, event_url))?;
 
     Ok(())
-}
-
-/// Returns `true` if the `tcp` feature is enabled.
-pub fn tcp_is_enabled() -> bool {
-    env::args().count() == 2
-}
-
-fn pack(event: &str, body: &[u8], content_type: MimeType) -> Vec<u8> {
-    todo!()
 }
 
 /// Post an event to the central message queue (Rapids), with a payload and its

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -19,7 +19,7 @@ pub fn get_args() -> Result<(String, Envelope), &'static str> {
     let envelope_str = args
         .pop()
         .ok_or("unable to read 'envelope' from program arguments")?;
-    let envelope = Envelope::new(envelope_str.as_str())?;
+    let envelope = Envelope::from_str(envelope_str.as_str())?;
     let action = args
         .pop()
         .ok_or("unable to read 'action' from program arguments")?;
@@ -41,12 +41,14 @@ fn read_next_byte_chunk(bytes: &[u8]) -> Result<(Vec<u8>, Vec<u8>), String> {
 }
 
 /// Used for tcp
-pub fn get_args_and_action() -> Result<(String, Envelope), String> {
+pub fn get_args_and_action() -> Result<(String, Envelope, Vec<u8>), String> {
     let bytes = get_bytes()?;
-    let (action, rest_bytes1) = read_next_byte_chunk(&bytes)?;
-    let (envelope, rest_bytes2) = read_next_byte_chunk(&rest_bytes1)?;
+    let (action_bytes, rest_bytes1) = read_next_byte_chunk(&bytes)?;
+    let (envelope_bytes, rest_bytes2) = read_next_byte_chunk(&rest_bytes1)?;
     let (payload, _) = read_next_byte_chunk(&rest_bytes2)?;
-    todo!()
+    let action = String::from_utf8(action_bytes).map_err(|e| e.to_string())?;
+    let envelope = Envelope::from_bytes(&envelope_bytes)?;
+    Ok((action, envelope, payload))
 }
 
 fn internal_post_http_to_rapids(

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -92,23 +92,7 @@ fn internal_http_post_to_rapids(
 
 fn pack(event: &str, body: &[u8], content_type: &MimeType) -> Result<Vec<u8>, String> {
     if event == "$reply" {
-        #[derive(Serialize)]
-        struct Headers {
-            #[serde(alias = "contentType")]
-            content_type: String,
-        }
-        #[derive(Serialize)]
-        struct Reply {
-            headers: Headers,
-            content: Vec<u8>,
-        }
-        let reply = Reply {
-            headers: Headers {
-                content_type: content_type.to_string(),
-            },
-            content: Vec::from(body),
-        };
-        serde_json::to_vec(&reply).map_err(|e| e.to_string())
+        pack_reply_payload(content_type, body)
     } else {
         let event = serde_json::to_vec(event).map_err(|e| e.to_string())?;
         let bytes = vec![
@@ -120,6 +104,26 @@ fn pack(event: &str, body: &[u8], content_type: &MimeType) -> Result<Vec<u8>, St
         .concat();
         Ok(bytes)
     }
+}
+
+fn pack_reply_payload(content_type: &MimeType, body: &[u8]) -> Result<Vec<u8>, String> {
+    #[derive(Serialize)]
+    struct Headers {
+        #[serde(alias = "contentType")]
+        content_type: String,
+    }
+    #[derive(Serialize)]
+    struct Reply {
+        headers: Headers,
+        content: Vec<u8>,
+    }
+    let reply = Reply {
+        headers: Headers {
+            content_type: content_type.to_string(),
+        },
+        content: Vec::from(body),
+    };
+    serde_json::to_vec(&reply).map_err(|e| e.to_string())
 }
 
 /// Post an event to the central message queue (Rapids), with a payload and its

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -98,6 +98,11 @@ fn internal_http_post_to_rapids(
 /// * `contentType` -- the content type of the payload
 pub fn post_to_rapids(event: &str, body: &[u8], content_type: MimeType) -> Result<(), String> {
     if tcp_is_enabled() {
+        /*
+            if event == "$reply"
+            then payload has shape { content: Vec<u8>, headers: { contentType: String } }
+            else payload is body
+        */
         // What to do with content_type?
         let event = serde_json::to_vec(event).map_err(|e| e.to_string())?;
         let body = Vec::from(body);

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -27,9 +27,18 @@ pub fn get_args() -> Result<(String, Envelope), &'static str> {
     Ok((action, envelope))
 }
 
-pub fn get_args_and_action() -> Result<(String, Envelope), &'static str> {
+/// Reads the bytes from stdin.
+fn get_bytes() -> Result<Vec<u8>, String> {
     let mut bytes: Vec<u8> = Vec::with_capacity(16); // 16 bytes is a fair minimum capacity
-    let stdin = io::stdin().read_to_end(&mut bytes);
+    let _ = io::stdin()
+        .read_to_end(&mut bytes)
+        .map_err(|e| e.to_string())?;
+    Ok(bytes)
+}
+
+/// Used for tcp
+pub fn get_args_and_action() -> Result<(String, Envelope), String> {
+    let bytes = get_bytes()?;
     todo!()
 }
 

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -37,7 +37,7 @@ fn get_bytes() -> Result<Vec<u8>, String> {
     Ok(bytes)
 }
 
-fn bytes_to_number(bytes: &[u8]) -> Result<usize, &'static str> {
+fn bytes_to_index(bytes: &[u8]) -> Result<usize, &'static str> {
     if bytes.len() < 3 {
         Err("byte vector too small to interpret as number")
     } else {
@@ -50,7 +50,7 @@ fn bytes_to_number(bytes: &[u8]) -> Result<usize, &'static str> {
 
 /// TODO: Maybe return `end` index instead so we avoid copying the bytes
 fn read_next_byte_chunk(bytes: &[u8]) -> Result<(Vec<u8>, Vec<u8>), &'static str> {
-    let len = bytes_to_number(&bytes[..3])?;
+    let len = bytes_to_index(&bytes[..3])?;
     let end = len + 3;
     Ok((Vec::from(&bytes[3..end]), Vec::from(&bytes[end..])))
 }

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -53,15 +53,19 @@ fn read_next_byte_chunk(bytes: &[u8]) -> Result<(Vec<u8>, usize), &'static str> 
 /// Returns the given `(action, envelope, payload)`.
 pub fn get_args() -> Result<(String, Envelope, Vec<u8>), String> {
     if tcp_is_enabled() {
-        get_tcp_args()
+        get_tcp_mode_args()
     } else {
-        let (action, envelope) = get_action_and_envelope()?;
-        let payload = get_bytes()?;
-        Ok((action, envelope, payload))
+        get_http_mode_args()
     }
 }
 
-fn get_tcp_args() -> Result<(String, Envelope, Vec<u8>), String> {
+fn get_http_mode_args() -> Result<(String, Envelope, Vec<u8>), String> {
+    let (action, envelope) = get_action_and_envelope()?;
+    let payload = get_bytes()?;
+    Ok((action, envelope, payload))
+}
+
+fn get_tcp_mode_args() -> Result<(String, Envelope, Vec<u8>), String> {
     let bytes = get_bytes()?;
     let (action_bytes, i) = read_next_byte_chunk(&bytes)?;
     let (envelope_bytes, j) = read_next_byte_chunk(&bytes[i..])?;

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -41,7 +41,6 @@ fn tcp_post_to_rapids(bytes: &[u8]) -> Result<(), String> {
 /// # Arguments
 /// * `event` --       the event to post
 /// * `body` --        the payload
-/// * `contentType` -- the content type of the payload
 pub fn post_str_to_rapids(event: &str, body: impl Into<String>) -> Result<(), String> {
     http_post_to_rapids(event, |r| {
         r.set("Content-Type", mime_types::TXT.to_string().as_str())

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -53,18 +53,22 @@ fn read_next_byte_chunk(bytes: &[u8]) -> Result<(Vec<u8>, usize), &'static str> 
 /// Returns the given `(action, envelope, payload)`.
 pub fn get_args() -> Result<(String, Envelope, Vec<u8>), String> {
     if tcp_is_enabled() {
-        let bytes = get_bytes()?;
-        let (action_bytes, i) = read_next_byte_chunk(&bytes)?;
-        let (envelope_bytes, j) = read_next_byte_chunk(&bytes[i..])?;
-        let (payload, _) = read_next_byte_chunk(&bytes[j..])?;
-        let action = String::from_utf8(action_bytes).map_err(|e| e.to_string())?;
-        let envelope = Envelope::from_bytes(&envelope_bytes)?;
-        Ok((action, envelope, payload))
+        get_tcp_args()
     } else {
         let (action, envelope) = get_action_and_envelope()?;
         let payload = get_bytes()?;
         Ok((action, envelope, payload))
     }
+}
+
+fn get_tcp_args() -> Result<(String, Envelope, Vec<u8>), String> {
+    let bytes = get_bytes()?;
+    let (action_bytes, i) = read_next_byte_chunk(&bytes)?;
+    let (envelope_bytes, j) = read_next_byte_chunk(&bytes[i..])?;
+    let (payload, _) = read_next_byte_chunk(&bytes[j..])?;
+    let action = String::from_utf8(action_bytes).map_err(|e| e.to_string())?;
+    let envelope = Envelope::from_bytes(&envelope_bytes)?;
+    Ok((action, envelope, payload))
 }
 
 /// Returns `true` if the `tcp` feature is enabled.

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -79,7 +79,7 @@ fn pack(event: &str, body: &[u8]) -> Vec<u8> {
     todo!()
 }
 
-fn internal_post_http_to_rapids(
+fn internal_http_post_to_rapids(
     event: &str,
     request_completer: impl FnOnce(Request) -> Result<Response, ureq::Error>,
 ) -> Result<(), String> {
@@ -104,7 +104,7 @@ pub fn post_to_rapids(event: &str, body: &[u8], content_type: MimeType) -> Resul
     if tcp_is_enabled() {
         internal_tcp_post_to_rapids(event, body)
     } else {
-        internal_post_http_to_rapids(event, |r| {
+        internal_http_post_to_rapids(event, |r| {
             r.set("Content-Type", content_type.to_string().as_str())
                 .send_bytes(body)
         })
@@ -129,7 +129,7 @@ pub fn post_str_to_rapids(
     body: impl Into<String>,
     content_type: MimeType,
 ) -> Result<(), String> {
-    internal_post_http_to_rapids(event, |r| {
+    internal_http_post_to_rapids(event, |r| {
         r.set("Content-Type", content_type.to_string().as_str())
             .send_string(body.into().as_str())
     })
@@ -139,7 +139,7 @@ pub fn post_str_to_rapids(
 /// # Arguments
 /// * `event` -- the event to post
 pub fn post_event_to_rapids(event: &str) -> Result<(), String> {
-    internal_post_http_to_rapids(event, |r| r.call())
+    internal_http_post_to_rapids(event, |r| r.call())
 }
 /// Post a reply back to the originator of the trace, with a payload and its
 /// content type.

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -75,7 +75,7 @@ pub fn tcp_is_enabled() -> bool {
     env::args().count() == 2
 }
 
-fn pack(event: &str, body: &[u8], content_type: MimeType) -> Vec<u8> {
+fn pack(event: &str, body: &[u8]) -> Vec<u8> {
     todo!()
 }
 
@@ -102,7 +102,7 @@ fn internal_post_http_to_rapids(
 /// * `contentType` -- the content type of the payload
 pub fn post_to_rapids(event: &str, body: &[u8], content_type: MimeType) -> Result<(), String> {
     if tcp_is_enabled() {
-        let packed = pack(event, body, content_type);
+        let packed = pack(event, body);
         let addr = env::var("RAPIDS").map_err(|_| "RAPIDS environment variable not set")?;
         let mut stream = net::TcpStream::connect(addr).map_err(|e| e.to_string())?;
         stream.write_all(&packed).map_err(|e| e.to_string())

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -26,7 +26,7 @@ pub fn get_args() -> Result<(String, Envelope), &'static str> {
     Ok((action, envelope))
 }
 
-fn internal_post_to_rapids(
+fn internal_post_http_to_rapids(
     event: &str,
     request_completer: impl FnOnce(Request) -> Result<Response, ureq::Error>,
 ) -> Result<(), String> {
@@ -48,7 +48,7 @@ fn internal_post_to_rapids(
 /// * `body` --        the payload
 /// * `contentType` -- the content type of the payload
 pub fn post_to_rapids(event: &str, body: &[u8], content_type: MimeType) -> Result<(), String> {
-    internal_post_to_rapids(event, |r| {
+    internal_post_http_to_rapids(event, |r| {
         r.set("Content-Type", content_type.to_string().as_str())
             .send_bytes(body)
     })
@@ -65,7 +65,7 @@ pub fn post_str_to_rapids(
     body: impl Into<String>,
     content_type: MimeType,
 ) -> Result<(), String> {
-    internal_post_to_rapids(event, |r| {
+    internal_post_http_to_rapids(event, |r| {
         r.set("Content-Type", content_type.to_string().as_str())
             .send_string(body.into().as_str())
     })
@@ -75,7 +75,7 @@ pub fn post_str_to_rapids(
 /// # Arguments
 /// * `event` -- the event to post
 pub fn post_event_to_rapids(event: &str) -> Result<(), String> {
-    internal_post_to_rapids(event, |r| r.call())
+    internal_post_http_to_rapids(event, |r| r.call())
 }
 /// Post a reply back to the originator of the trace, with a payload and its
 /// content type.

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -4,6 +4,7 @@ use std::env;
 use std::fs::File;
 use std::io::{self, Read, Write};
 use std::net;
+use std::str::FromStr;
 use ureq::{Request, Response};
 
 pub fn get_payload() -> Result<Vec<u8>, &'static str> {
@@ -36,7 +37,19 @@ fn get_bytes() -> Result<Vec<u8>, String> {
     Ok(bytes)
 }
 
+fn bytes_to_number(bytes: &[u8]) -> Result<u32, &'static str> {
+    if bytes.len() < 3 {
+        Err("byte vector too small to interpret as number")
+    } else {
+        let left = u32::from(bytes[0]) << 16;
+        let mid = u32::from(bytes[1]) << 8;
+        let right = u32::from(bytes[2]);
+        Ok(left | mid | right)
+    }
+}
+
 fn read_next_byte_chunk(bytes: &[u8]) -> Result<(Vec<u8>, Vec<u8>), String> {
+    let len = bytes_to_number(&bytes[..2])?;
     todo!()
 }
 
@@ -212,3 +225,6 @@ pub fn broadcast_to_channel(
         mime_types::JSON,
     )
 }
+
+#[cfg(test)]
+mod test {}

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -36,9 +36,16 @@ fn get_bytes() -> Result<Vec<u8>, String> {
     Ok(bytes)
 }
 
+fn read_next_byte_chunk(bytes: &[u8]) -> Result<(Vec<u8>, Vec<u8>), String> {
+    todo!()
+}
+
 /// Used for tcp
 pub fn get_args_and_action() -> Result<(String, Envelope), String> {
     let bytes = get_bytes()?;
+    let (action, rest_bytes1) = read_next_byte_chunk(&bytes)?;
+    let (envelope, rest_bytes2) = read_next_byte_chunk(&rest_bytes1)?;
+    let (payload, _) = read_next_byte_chunk(&rest_bytes2)?;
     todo!()
 }
 

--- a/src/merrymake.rs
+++ b/src/merrymake.rs
@@ -94,16 +94,20 @@ fn pack(event: &str, body: &[u8], content_type: &MimeType) -> Result<Vec<u8>, St
     if event == "$reply" {
         pack_reply_payload(content_type, body)
     } else {
-        let event = serde_json::to_vec(event).map_err(|e| e.to_string())?;
-        let bytes = vec![
-            &length_to_bytes(event.len())[..],
-            event.as_slice(),
-            &length_to_bytes(body.len())[..],
-            body,
-        ]
-        .concat();
-        Ok(bytes)
+        pack_rapids_payload(event, body)
     }
+}
+
+fn pack_rapids_payload(event: &str, body: &[u8]) -> Result<Vec<u8>, String> {
+    let event = serde_json::to_vec(event).map_err(|e| e.to_string())?;
+    let bytes = vec![
+        &length_to_bytes(event.len())[..],
+        event.as_slice(),
+        &length_to_bytes(body.len())[..],
+        body,
+    ]
+    .concat();
+    Ok(bytes)
 }
 
 fn pack_reply_payload(content_type: &MimeType, body: &[u8]) -> Result<Vec<u8>, String> {


### PR DESCRIPTION
The build time is significantly decreased since it does not rely `tokio` anymore. Introduces some minor breaking changes by requiring borrows values instead of taking ownership.

Also adds TCP functionality.

- [x] `ureq` impl
- [x] `tcp` feature

Closes #5 